### PR TITLE
Changed area to property

### DIFF
--- a/docs/advantages.rst
+++ b/docs/advantages.rst
@@ -47,7 +47,7 @@ an instance variable as with standard python programming for direct use.
 
     with BuildSketch() as plan:
         r = Rectangle(width, height)
-        print(r.Area())
+        print(r.area)
         ...
 
 Operators


### PR DESCRIPTION
Small change to documentation as `Rectangle.Area()` does not (anymore?) exist but `Rectangle.area` is a property now.